### PR TITLE
GitHub pages css

### DIFF
--- a/module-03/personal-github-page/index.html
+++ b/module-03/personal-github-page/index.html
@@ -19,6 +19,10 @@
             text-decoration: none;
             color: #083D77;
         }
+
+        ul {
+            font-size: 20px;
+        }
     </style>
 </head>
 <body>

--- a/module-03/personal-github-page/index.html
+++ b/module-03/personal-github-page/index.html
@@ -23,10 +23,15 @@
         ul {
             font-size: 20px;
         }
+
+        img {
+            border-radius: 50%;
+        }
     </style>
 </head>
 <body>
     <h1>Havyner Caetano</h1>
+    <hr>
     <h3>Index of contents</h3>
     <ul>
         <li><a href="#picture">Picture</a></li>
@@ -38,11 +43,14 @@
     Is learning the JavaScript stack at Trybe.<br><br>
     Lives in Rio Grande, southern Brazil.</p>
     <h3 id="skills">My skills</h3>
+    <hr>
     <ul>
         <li>Swims <em>badly</em></li>
         <li>Plays Magic: The Gathering</li>
         <li><strong>Always heals/ressurects the party</strong></li>
     </ul>
+    <hr>
+    <h3>Blog recomendation</h3>
     <a id="blog" target="_blank" href="https://magic.wizards.com/en/articles/columns/making-magic">Here is a link to the best Magic: The Gathering blog.</a>
 </body>
 </html>

--- a/module-03/personal-github-page/index.html
+++ b/module-03/personal-github-page/index.html
@@ -11,6 +11,8 @@
 
         body {
             font-family: Tahoma, Verdana, sans-serif;
+            background-color: #5390d9;
+            color: white;
         }
     </style>
 </head>

--- a/module-03/personal-github-page/index.html
+++ b/module-03/personal-github-page/index.html
@@ -14,6 +14,11 @@
             background-color: #5390d9;
             color: white;
         }
+
+        a {
+            text-decoration: none;
+            color: #083D77;
+        }
     </style>
 </head>
 <body>

--- a/module-03/personal-github-page/index.html
+++ b/module-03/personal-github-page/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Havyner Caetano's personal page</title>
+    <style>
+        h1 {
+            font-family: Helvetica, Arial, sans-serif;
+        }
+
+        body {
+            font-family: Tahoma, Verdana, sans-serif;
+        }
+    </style>
 </head>
 <body>
     <h1>Havyner Caetano</h1>


### PR DESCRIPTION
Add styling to the personal GitHub page. Now, the page has a blue background, the font family of the h1 is Tahoma and the body's is Verdana. Except for the links, all text color is now white. Image is now round. Sections are mostly separated by hr elements